### PR TITLE
Git usage with single main branch

### DIFF
--- a/Continuous integration.md
+++ b/Continuous integration.md
@@ -85,7 +85,6 @@ experimental:
   notify:
     branches:
       only:
-        - master
         - labs
         - dev
 ```
@@ -110,9 +109,9 @@ This will significantly speed up the compilation of your apps on CircleCI.
 
 ## Protected branches
 
-In the git flow model that is applied in Infinum, the `dev` and `master` branches have a special role in the development and release cycle. It is expected that the code is not pushed directly to those two branches; therefore the branches need to be set as protected. Also, in order to make sure that the code in those two branches builds successfully at any time and always satisfies static analysis rules and any other rules defined in `circle.yml`, CircleCI needs to be enabled on `dev` and `master`.
+In the git flow model that is applied in Infinum, the `dev` and `release` branches have a special role in the development and release cycle. It is expected that the code is not pushed directly to those two branches; therefore the branches need to be set as protected. Also, in order to make sure that the code in those two branches builds successfully at any time and always satisfies static analysis rules and any other rules defined in `circle.yml`, CircleCI needs to be enabled on `dev` and `release`.
 
-First, the `dev` and `master` branch need to be set as protected. In order to set them as protected, administrator rights are required on the working project. The administrator user can click on the Settings button, as depicted in the picture
+First, the `dev` and `release` branch need to be set as protected. In order to set them as protected, administrator rights are required on the working project. The administrator user can click on the Settings button, as depicted in the picture
 
 ![Click on the Settings](/img/CI-protect-branch-click-setting.png)
 
@@ -127,5 +126,3 @@ Next, select the `dev` branch in the `Protected branches` section.
 Mark the check boxes as shown.
 
 ![Mark check boxes](/img/CI-protect-branch-check.png)
-
-Do the same for the `master` branch.

--- a/Play Store.md
+++ b/Play Store.md
@@ -5,7 +5,7 @@ When releasing an application to the Google Play Store, you should make sure you
 3. Build the signed and obfuscated release version of the application
 4. Test the application manually; make sure all API endpoints are pointing to production
 5. Upload the release .apk to the Play Store
-6. Add a tag for the version on master branch. Find out more about tagging in the [Git usage section](/git-usage)
+6. Add a tag for the version on dev/release branch. Find out more about tagging in the [Git usage section](/git-usage)
 
 If your app is already on the Play Store, take special care to **test the update** of your app:
 

--- a/Play Store.md
+++ b/Play Store.md
@@ -5,7 +5,7 @@ When releasing an application to the Google Play Store, you should make sure you
 3. Build the signed and obfuscated release version of the application
 4. Test the application manually; make sure all API endpoints are pointing to production
 5. Upload the release .apk to the Play Store
-6. Add a tag for the version on dev/release branch. Find out more about tagging in the [Git usage section](/git-usage)
+6. Add a tag for the version on `dev`/`release` branch. Find out more about tagging in the [Git usage section](/git-usage)
 
 If your app is already on the Play Store, take special care to **test the update** of your app:
 

--- a/Project setup.md
+++ b/Project setup.md
@@ -2,7 +2,7 @@
 
 1. Create a private Git repository on Github/Bitbucket
 2. Create an empty `dev` branch, set it as default branch, and protected if possible
-3. If you are going to use `release` branches add protection regex with same rules as for the dev branch 
+3. If you are going to use `release` branches add protection regex with same rules as for the `dev` branch 
 4. Ask the project manager to provide you with all project documentation and design
 
 ## Initial project setup

--- a/Project setup.md
+++ b/Project setup.md
@@ -1,8 +1,8 @@
 ## Before starting work
 
 1. Create a private Git repository on Github/Bitbucket
-2. Create an empty `master` and `dev` branch, mark them protected if possible
-3. Set `dev` as the default branch
+2. Create an empty `dev` branch, set it as default branch, and protected if possible
+3. If you are going to use `release` branches add protection regex with same rules as for the dev branch 
 4. Ask the project manager to provide you with all project documentation and design
 
 ## Initial project setup

--- a/Pull requests.md
+++ b/Pull requests.md
@@ -2,7 +2,7 @@ Pull requests are the essential part of our workflow. This section describes how
 
 ### General rules
 - A pull request cannot be merged until the CI build passes
-- The dev and release branches should be set as protected, which means no one can force push to them, and they can't be deleted. If you are not sure how to set them as protected, or you don't have access, ask one of the team leads to do it for you.
+- The `dev` and `release` branches should be set as protected, which means no one can force push into them, and they can't be deleted. If you are not sure how to set them as protected, or you don't have access, ask one of the team leads to do it for you.
 
 ### Creating a pull request
 

--- a/Pull requests.md
+++ b/Pull requests.md
@@ -2,7 +2,7 @@ Pull requests are the essential part of our workflow. This section describes how
 
 ### General rules
 - A pull request cannot be merged until the CI build passes
-- The master and development branch should be set as protected, which means no one can force push to them, and they can't be deleted. If you are not sure how to set them as protected, or you don't have access, ask one of the team leads to do it for you.
+- The dev and release branches should be set as protected, which means no one can force push to them, and they can't be deleted. If you are not sure how to set them as protected, or you don't have access, ask one of the team leads to do it for you.
 
 ### Creating a pull request
 

--- a/Using Git.md
+++ b/Using Git.md
@@ -4,14 +4,15 @@ Just remember to clone the repository using the [SSH clone URL](https://help.git
 
 ## Git Flow
 
-We use a variant of the [Git Flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) workflow. The difference between our variant and the linked document is that we don't use release branches.
-You can find a more detailed explanation of Git Flow [here](http://nvie.com/posts/a-successful-git-branching-model/).
+We use a variant of the [Git Flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) workflow. There are some differences between our variant and the linked document. The main one is we don't need the master branch. Also, on most projects we don't use release branches. 
 
 ![Git Flow](/img/git-flow.svg)
 
-There are two main branches, `master` and `dev`.
+By definition, there are two main branches, `master` and `dev`.
 The `master` branch contains **only published code** at all times, and each release is **tagged** with the version number.
 The `dev` branch serves for integration of various features/fixes developed in separate branches.
+
+We noticed that the master branch is not used that often. Since we have tags on release commits having a branch that only contains published code looks like unnecessary. That is why for the simplicity we only keep the dev branch as main branch. In the dev branch we track we integrate all the feature/fixes and track releases via tags. 
 
 ## Git tagging
 
@@ -59,6 +60,16 @@ or by merging `dev` into your branch
 git checkout feature/login-screen
 git merge dev
 ```
+
+### Release branches
+
+Most of the projects have one active stream at the moment. This means that all of the work done by developer can go directly into the dev branch. All the work goes into the next release so there is no need to seperate the dev branch into mulitple release branches. 
+
+However, some projects have multiple releases plan ahead. It is possible that at some point a development team will work on multiple releases at the same time. In that case, `release` branches should be introduced. Protect this branches as you do for your main branch. You can use regex to match all the release branches and not worry about protecting a newly create ones. **Note:** If you want to delete a protected branch on Github you will need to remove the protection cause this can't be done even with admin privilege. 
+
+To be able to work with release branches we need to have defined version for each specified task. If you are not certain in which version some task is plan to be release ask the project manage before strating the work. In (Productive)[[https://app.productive.io](https://app.productive.io/)] release versions can be defined with `tags` or `task list`. In (JIRA)[<https://www.atlassian.com/software/jira>] you can track the status of each release and define `Fix version/s` attribute on a task.
+
+When working with release branches make sure you set a tag on the last commit in the release branch. You should do this before merging the code to the dev branch. After publishing and merging release branch to dev, don't forget to also update all other active release branches.  
 
 ### Commit early, commit often
 

--- a/Using Git.md
+++ b/Using Git.md
@@ -4,7 +4,7 @@ Just remember to clone the repository using the [SSH clone URL](https://help.git
 
 ## Git Flow
 
-We use a variant of the [Git Flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) workflow. There are some differences between our variant and the linked document. The main one is we don't need the master branch. Also, on most projects we don't use release branches. 
+We use a variant of the [Git Flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) workflow. There are some differences between our variant and the linked document. The main one is we don't need the `master` branch. Also, on most projects we don't use `release` branches. 
 
 ![Git Flow](/img/git-flow.svg)
 
@@ -12,7 +12,7 @@ By definition, there are two main branches, `master` and `dev`.
 The `master` branch contains **only published code** at all times, and each release is **tagged** with the version number.
 The `dev` branch serves for integration of various features/fixes developed in separate branches.
 
-We noticed that the master branch is not used that often. Since we have tags on release commits having a branch that only contains published code looks like unnecessary. That is why for the simplicity we only keep the dev branch as main branch. In the dev branch we track we integrate all the feature/fixes and track releases via tags. 
+We noticed that the `master` branch is not used that often. Since we have tags on release commits, having a branch that only contains published code seems unnecessary. That is why, for the simplicity, we only keep the `dev` branch as the main branch and track releases via tags.
 
 ## Git tagging
 
@@ -63,13 +63,13 @@ git merge dev
 
 ### Release branches
 
-Most of the projects have one active stream at the moment. This means that all of the work done by developer can go directly into the dev branch. All the work goes into the next release so there is no need to seperate the dev branch into mulitple release branches. 
+Most projects have one active development stream at the moment. This means that all new changes should be included in the next upcoming release. Because of this, all changes can be merged into the `dev` branch without the need to introduce multiple `release` branches.
 
-However, some projects have multiple releases plan ahead. It is possible that at some point a development team will work on multiple releases at the same time. In that case, `release` branches should be introduced. Protect this branches as you do for your main branch. You can use regex to match all the release branches and not worry about protecting a newly create ones. **Note:** If you want to delete a protected branch on Github you will need to remove the protection cause this can't be done even with admin privilege. 
+However, some projects have multiple releases planned ahead. It is possible that at some point a development team will work on multiple releases at the same time. In that case, `release` branches should be introduced and handled in the same manner as the main `dev` branch. You can use regex to match all the release branches and not worry about protecting newly created ones. **Note:** If you want to delete a protected branch on GitHub you will need to remove the protection because this can't be done even with admin privileges. 
 
-To be able to work with release branches we need to have defined version for each specified task. If you are not certain in which version some task is plan to be release ask the project manage before strating the work. In (Productive)[[https://app.productive.io](https://app.productive.io/)] release versions can be defined with `tags` or `task list`. In (JIRA)[<https://www.atlassian.com/software/jira>] you can track the status of each release and define `Fix version/s` attribute on a task.
+When working with `release` branches, it needs to be clear which task should be included in which version. If you are not sure of this, ask the project manager before starting with the task. In (Productive)[[https://app.productive.io](https://app.productive.io/)] release versions can be defined with tags or boards. In (JIRA)[<https://www.atlassian.com/software/jira>] you can track the status of each release and define `Fix version/s` attribute on a task.
 
-When working with release branches make sure you set a tag on the last commit in the release branch. You should do this before merging the code to the dev branch. After publishing and merging release branch to dev, don't forget to also update all other active release branches.  
+After releasing a new version from the `release` branch, make sure to create a new tag with that version from the last commit in that branch. Then you can merge the `release` branch into the `dev` branch. Don't forget to also update all other active `release` branches.
 
 ### Commit early, commit often
 


### PR DESCRIPTION
Suggestion for a change to ditch not so used master branch. 
Previously we stated that we are not using release branch but now we do. Philips and RBA can't function without release branches. On the other hand not sure when was the last time we used master for a hotfix and we can do the same thing with checking out a tagged commit. 