### PR TITLE
step for downloading java is no longer needed

### DIFF
--- a/Development environment setup.md
+++ b/Development environment setup.md
@@ -6,7 +6,7 @@
 
 ## Setup java JDK
 
-Java JDK comes embedded in android studio and is often more compatible, therefore we don't need to install new JDK. However android studio by default uses systems JDK so project structure needs to be changed in order to use embedded one.
+Java JDK comes embedded in Android studio and is often more compatible, therefore we don't need to install new JDK. However Android studio by default uses systems JDK so project structure needs to be changed in order to use embedded one.
 
 - On welcome screen go to Configure -> Default project structure... and change JDK location to Embedded JDK
 - If you have opened a project without following the first step go to File -> Project structure... -> SDK Location and change JDK location to Embedded JDK, then go to File -> Other settings -> Default project structure... and change JDK location to Embedded JDK

--- a/Development environment setup.md
+++ b/Development environment setup.md
@@ -1,9 +1,13 @@
 ## Install basic tools
 
-- [Latest Oracle JDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 - [Android Studio](https://developer.android.com/studio/index.html)
 - Git—`brew install git` ([brew docs](http://brew.sh/))
 - Zeplin—`brew cask install zeplin` ([brew cask docs](https://caskroom.github.io/))
+
+## Setup java JDK
+
+- On welcome screen go to Configure -> Default project structure... and change JDK location to Embedded JDK
+- If you have opened a project without following the first step go to File -> Project structure... -> SDK Location and change JDK location to Embedded JDK, then go to File -> Other settings -> Default project structure... and change JDK location to Embedded JDK
 
 ## Import code style
 

--- a/Development environment setup.md
+++ b/Development environment setup.md
@@ -6,7 +6,7 @@
 
 ## Setup java JDK
 
-Java JDK comes embedded in Android studio and is often more compatible, therefore we don't need to install new JDK. However Android studio by default uses systems JDK so project structure needs to be changed in order to use embedded one.
+Java JDK comes embedded in Android studio and is often more compatible, therefore we don't need to manually download and install JDK. However Android studio by default uses systems JDK so project structure needs to be changed in order to use embedded one.
 
 - On welcome screen go to Configure -> Default project structure... and change JDK location to Embedded JDK
 - If you have opened a project without following the first step go to File -> Project structure... -> SDK Location and change JDK location to Embedded JDK, then go to File -> Other settings -> Default project structure... and change JDK location to Embedded JDK

--- a/Development environment setup.md
+++ b/Development environment setup.md
@@ -6,6 +6,8 @@
 
 ## Setup java JDK
 
+Java JDK comes embedded in android studio and is often more compatible, therefore we don't need to install new JDK. However android studio by default uses systems JDK so project structure needs to be changed in order to use embedded one.
+
 - On welcome screen go to Configure -> Default project structure... and change JDK location to Embedded JDK
 - If you have opened a project without following the first step go to File -> Project structure... -> SDK Location and change JDK location to Embedded JDK, then go to File -> Other settings -> Default project structure... and change JDK location to Embedded JDK
 

--- a/Libraries.md
+++ b/Libraries.md
@@ -10,7 +10,7 @@
 
 	ViewPagerIndicator provides us with paging indicator widgets compatible with the ViewPager. It helps you provide a clear indicator that additional content exist.
 
-	More info with code examples is available [here](http://viewpagerindicator.com/).
+	More info with code examples is available [here](https://github.com/JakeWharton/ViewPagerIndicator).
 
 3. **CircleImageView**
 

--- a/Project architecture.md
+++ b/Project architecture.md
@@ -40,7 +40,7 @@ However, the SingleLiveEvent implementation from Google has one major setback—
 
 - **Canceling network calls**
 
-Since we have LiveDate to take care of lifecycle state changes, we don't have to worry that much about async work that loads our data. We can set the data to LiveData at any time without fear that this is going to crash our app because the View is not ready. This means there is no need to cancel a network call when activity is moved to the background. So, no unnecessary data traffic, repeated calls, checks if we already have the data, or in-memory cache in the activity scope. 
+Since we have LiveData to take care of lifecycle state changes, we don't have to worry that much about async work that loads our data. We can set the data to LiveData at any time without fear that this is going to crash our app because the View is not ready. This means there is no need to cancel a network call when activity is moved to the background. So, no unnecessary data traffic, repeated calls, checks if we already have the data, or in-memory cache in the activity scope. 
 
 - **Recreating an activity and state preservation**
 


### PR DESCRIPTION
Java JDK comes embedded in android studio and is more compatible, hence the step for downloading Oracles Java isn't necessary. However android studio by default uses systems JDK so project structure needs to be changed to correct this issue. Also LiveDate is changed to LIveData since that is what was meant.