### PR TITLE
Move in-house libraries to public repo

### DIFF
--- a/Useful tools & utilities/In-house libraries.md
+++ b/Useful tools & utilities/In-house libraries.md
@@ -1,0 +1,37 @@
+
+Often, there will be problems experienced by more than one person in the team or some code which is shared between multiple projects. Those present an excellent opportunity to form a common solution into an open-source library, helping anyone that could make use of it, inside or outside of the company. When creating a library, we strive to make it straightforward, easy-to-use and applicable to everyone, rather than limiting it to our use-cases. 
+
+Developing a library is like working on your mini-project. It can provide you with a sense of pride and accomplishment, as well as being a great learning opportunity. We encourage anyone with ideas to pitch them to our librarian [@JonatanPlesko](https://github.com/JonatanPlesko).
+
+### [Prince of Versions](https://github.com/infinum/Android-Prince-of-Versions)
+Prince of Versions is a library for handling application updates. We use it on almost every project as it solves the issue of handling optional and mandatory updates. 
+It is split into two modules: 
+
+* **Queen of Versions** - checks update availability using [in-app updates](https://developer.android.com/guide/playcore/in-app-updates)
+
+* **Prince of Versions** - checks for updates via a remote or local source (usually a JSON file on the server).
+
+### [Sentinel](https://github.com/infinum/android-sentinel)
+
+Sentinel is a simple one screen UI which provides a standardised entry point for tools used in development and QA alongside device, application and permissions data. Including it in your project has a good chance of making your QA very happy, as well as making debugging easier, especially with networking, database, or analytics issues.
+
+### [DbInspector](https://github.com/infinum/android_dbinspector)
+
+DbInspector is a library for viewing the contents of the in-app database for debugging purposes. While somewhat replaced by the new [Android Studio's Database Inspector feature](https://developer.android.com/studio/preview/features#database-inspector), it is useful for QA and is included as a Sentinel tool.
+
+### [Retromock](https://github.com/infinum/Retromock)
+
+Retromock is a library for mocking responses in a Retrofit service. It uses annotations and is very simple and intuitive to implement. If you work for a project with an inconsistent API uptime or are ahead of the backend team in the development, you will undoubtedly find it useful. 
+
+### [ConnectionBuddy](https://github.com/zplesac/android_connectionbuddy)
+
+ConnectionBuddy is a utility library for handling connectivity change events. It provides a simple way of listening to connectivity events, particularly useful for applications which need to change behaviour dynamically based on the connection state.
+
+### [Goldfinger](https://github.com/infinum/Android-Goldfinger)
+
+Goldfinger is a library which simplifies biometric authentication implementation - our go-to on projects which use biometrics.
+
+### [GoldenEye](https://github.com/infinum/Android-GoldenEye)
+
+GoldenEye is a wrapper for Camera1 and Camera2 API which exposes simple to use interface. Android camera is infamously difficult to use, and GoldenEye is our take at simplifying it.
+

--- a/Useful tools & utilities/In-house libraries.md
+++ b/Useful tools & utilities/In-house libraries.md
@@ -1,7 +1,7 @@
 
 Often, there will be problems experienced by more than one person in the team or some code which is shared between multiple projects. Those present an excellent opportunity to form a common solution into an open-source library, helping anyone that could make use of it, inside or outside of the company. When creating a library, we strive to make it straightforward, easy-to-use and applicable to everyone, rather than limiting it to our use-cases. 
 
-Developing a library is like working on your mini-project. It can provide you with a sense of pride and accomplishment, as well as being a great learning opportunity. We encourage anyone with ideas to pitch them to our librarian [@JonatanPlesko](https://github.com/JonatanPlesko).
+Developing a library is like working on your mini-project. It can provide you with a sense of pride and accomplishment, as well as being a great learning opportunity.
 
 ### [Prince of Versions](https://github.com/infinum/Android-Prince-of-Versions)
 Prince of Versions is a library for handling application updates. We use it on almost every project as it solves the issue of handling optional and mandatory updates. 
@@ -34,4 +34,3 @@ Goldfinger is a library which simplifies biometric authentication implementation
 ### [GoldenEye](https://github.com/infinum/Android-GoldenEye)
 
 GoldenEye is a wrapper for Camera1 and Camera2 API which exposes simple to use interface. Android camera is infamously difficult to use, and GoldenEye is our take at simplifying it.
-


### PR DESCRIPTION
We've decided that we're going to be making our "In-house libraries" page public. This in turn caused some content changes:

1.The Android Polyglot plugin has been removed (which is OK because we have a separate page for it anyways)
2. Collar has been removed (it will be added once again when it goes public, so soon-ish)
3. The "librarian" link to the responsibilities page has been replaced with Jonatan's Github handle, so that it's more compatible with the outside world. I was winging this, so if we don't like it, we can just remove the entire sentence.

There'll be a matching PR in the private handbook for the removal of this page.