### PR TITLE
`Project readme` goes public

### DIFF
--- a/Building quality apps/Project readme.md
+++ b/Building quality apps/Project readme.md
@@ -1,0 +1,20 @@
+A good readme is essential so that anyone who access a repository can find relevant documentation and understand what the project is about.
+
+Every project is different, but there are some common things which every readme has to contain. The order is not random, the readme should be in this order.
+
+1. **Application name** - Even if the name of the repo is the same as the application name.
+2. **Bitrise badge** - For the default branch. https://devcenter.bitrise.io/api/app-status-badge/
+3. **Description** - Write down what the app is used for.
+4. **Architecture** - A quick overview of the architecture and a list of programming languages
+5. **API documentation** - A link and a short description. The description is needed only if there is something out of the ordinary (JSON-API, XML…). If the documentation doesn’t exist, push the backend developers to create one.
+6. **Design** - Link to the design. Most of the time this is a link to the Zeplin project, but depending on the project, it can be something else.
+7. **Important services**
+A link to important services. You can add other services if they are relevant.
+    * Labs
+    * Productive/Jira/etc.
+    * Polyglot
+    * Firebase
+    * Google console project
+    * Google play  
+8. **How to deploy a new build** - Instructions on how to deploy a new build.
+9. **Project specifics**. This section is not mandatory, but if there's anything specific to the project write it in this section.

--- a/Project structure/Project setup.md
+++ b/Project structure/Project setup.md
@@ -17,7 +17,7 @@
 9. Set up Firebase on the Infinum or client account if available (make sure that caught exceptions are also logged using [Timber](https://github.com/JakeWharton/timber)).
 10. Add app icons with a different icon for non-production server targets (we usually use a banner overlay on the icon saying 'test' or 'staging').
 11. Add the appropriate ProGuard configuration depending on the libraries used.
-12. Create README.md (see the [Readme](/books/android/internal-section/project-readme) chapter for details). 
+12. Create README.md (see the [Readme](/books/android/building-quality-apps/project-readme) chapter for details). 
 13. Open a pull request to the appropriate colleague.
 
 The first pull request should contain only the initial setup code so that it's easier to review.


### PR DESCRIPTION
The `project readme` page doesn't contain any proprietary information and is a generally useful piece of text, so I'm making it public.

This move will also fix the issue of one of our public pages linking to a private page (`project setup` page has a link to the `project readme`).