### PR TITLE
Add Complexify and Thrifty Retrofit converter to in-house libraries

### DIFF
--- a/Useful tools & utilities/In-house libraries.md
+++ b/Useful tools & utilities/In-house libraries.md
@@ -23,6 +23,10 @@ DbInspector is a library for viewing the contents of the in-app database for deb
 
 Retromock is a library for mocking responses in a Retrofit service. It uses annotations and is very simple and intuitive to implement. If you work for a project with an inconsistent API uptime or are ahead of the backend team in the development, you will undoubtedly find it useful. 
 
+### [Complexify](https://github.com/infinum/android-complexify)
+
+Complexify provides a simple API for checking the quality of a password. You can configure how strong the password has to be, the minimum amount of characters, and ban the most commonly used passwords (or use your own ban list).
+
 ### [ConnectionBuddy](https://github.com/zplesac/android_connectionbuddy)
 
 ConnectionBuddy is a utility library for handling connectivity change events. It provides a simple way of listening to connectivity events, particularly useful for applications which need to change behaviour dynamically based on the connection state.

--- a/Useful tools & utilities/In-house libraries.md
+++ b/Useful tools & utilities/In-house libraries.md
@@ -27,6 +27,10 @@ Retromock is a library for mocking responses in a Retrofit service. It uses anno
 
 ConnectionBuddy is a utility library for handling connectivity change events. It provides a simple way of listening to connectivity events, particularly useful for applications which need to change behaviour dynamically based on the connection state.
 
+### [Thrifty Retrofit converter](https://github.com/infinum/thrifty-retrofit-converter)
+
+Thrifty Retrofit converter is a [Retrofit](https://github.com/square/retrofit) converter which uses [Thrifty](https://github.com/Microsoft/thrifty) for (de)serialization of Apache Thrift requests and responses.
+
 ### [Goldfinger](https://github.com/infinum/Android-Goldfinger)
 
 Goldfinger is a library which simplifies biometric authentication implementation - our go-to on projects which use biometrics.


### PR DESCRIPTION
Thrifty Retrofit converter was too long on my todo list to add here. As for Complexify, I wasn't sure if we were going to keep it alive, but now I've done some work on it and it seems like a good (and simple) library to keep around.