### PR TITLE
Remove link to the private handbook within Naming page

### DIFF
--- a/Building quality apps/Naming.md
+++ b/Building quality apps/Naming.md
@@ -51,7 +51,7 @@ if (checkFileSize(image))
 * Activities and fragments are named with the appropriate suffix: `LoginActivity`, `RegisterFragment`.
 * The corresponding layouts have to be named with the appropriate prefix: `activity_login.xml`, `fragment_register.xml`.
 * All naming has to be simple, clear and mnemonic (short and meaningful).
-* The [Infinum Code Style](https://github.com/infinum/android-handbook/blob/master/files/InfinumCodeStyle.xml) has to be imported into the Android Studio and used in formatting code. If you want to find out how to import it, check out the chapter about [Development environment setup](/books/android/onboarding/development-environment-setup).
+* The [Infinum Code Style](https://github.com/infinum/android-handbook/blob/master/files/InfinumCodeStyle.xml), made for use with Android Studio, offers a simple way to auto-format code following most of the conventions stated above.
 * Drawable resources also have [naming conventions](http://petrnohejl.github.io/Android-Cheatsheet-For-Graphic-Designers/#naming-conventions).
 
 ## Examples of good naming


### PR DESCRIPTION
### Productive task:
- [Links to private handbook bug](https://app.productive.io/1-infinum/projects/566/tasks/task/1486816?board=97777)

### Changes
 - Removed the `Development environment setup` link from the `Naming` page as it leads to the private part of the handbook and results in a 404 for non-registered users