### PR TITLE
Update Project setup chapter with the project template workflow

### DIFF
--- a/Project structure/Project setup.md
+++ b/Project structure/Project setup.md
@@ -1,23 +1,12 @@
-## Before starting work
+## Repository setup
 
-1. Ask your Tech/Team leader to create a private Git repository on Github/Bitbucket.
-2. If you are going to use `release` branches, add protection regex with same rules as for the `main` branch.
-3. Ask the project manager to provide you with all project documentation and design.
+Ask a Lead Engineer to set up the repository on GitHub. If you're a Lead Engineer, follow the [Repository setup](https://github.com/infinum/LE-wiki/wiki/Repository-setup) guide on the LE wiki.
 
-## Initial project setup
+## Project setup
 
-1. Branch a new branch off `main` (see the [Using Git](/books/android/building-quality-apps/using-git) chapter for details).
-2. Create a new project in Android Studio using the wizard.
-3. Create a gitignore file using [gitignore.io](https://www.gitignore.io/).
-4. Set up buildTypes and flavors (you usually need a `staging` and `production` flavor).
-5. Generate a development keystore with random passwords and add the configuration to `build.gradle`. The production keystore management is explained in the [Keystore management](/books/android/common-android/keystore-management) chapter.
-6. Add static analysis and CI configuration as described in the `Continuous integration` chapter.
-7. Add an Application class and Timber, set up Timber in the app class.
-8. Set up basic networking and test code with dependency injection (see the [Dependency injection](/books/android/dependency-injection/general) chapter for details).
-9. Set up Firebase on the Infinum or client account if available (make sure that caught exceptions are also logged using [Timber](https://github.com/JakeWharton/timber)).
-10. Add app icons with a different icon for non-production server targets (we usually use a banner overlay on the icon saying 'test' or 'staging').
-11. Add the appropriate ProGuard configuration depending on the libraries used.
-12. Create README.md (see the [Readme](/books/android/building-quality-apps/project-readme) chapter for details). 
-13. Open a pull request to the appropriate colleague.
-
-The first pull request should contain only the initial setup code so that it's easier to review.
+1. Clone the project repository and open it in Android Studio.
+2. Follow the instructions from the TEMPLATE_README.md file (in the root of the project).
+3. Create a pull request with the above changes before continuing with the rest of the setup.
+4. Set up [CI & code analysis](/books/android/ci-and-code-analysis/continuous-integration).
+5. Update minimum, target and compile SDK to the values agreed with the client.
+6. Update README.md (see the [Readme](/books/android/building-quality-apps/project-readme) chapter for details). Make sure to keep updating it as you progress with the project.


### PR DESCRIPTION
Now that we started using the [New project template](https://github.com/infinum/android-new-project-template), the previous guide did not make sense as most of these things were already set up by the template.

I cut down most of the content, including some things that might be project-specific. Not every project immediately needs additional flavors or a Firebase setup, so I wouldn't consider those a part of the _initial_ project setup. You're welcome to fight me on this one!

Finally, I'd also ask the LEs (@antunflas & @schalke95) to review the linked [Repository setup](https://github.com/infinum/LE-wiki/wiki/Repository-setup) document that I just wrote to complement these changes. That part will have to be done by the LEs in the future since it requires owner access on the GitHub organization level. Other team members do not have access to that link since they do not need to perform any of those steps.