### PR TITLE
Update code style with line break after mutiline when entry rule

### DIFF
--- a/files/InfinumCodeStyle.xml
+++ b/files/InfinumCodeStyle.xml
@@ -31,6 +31,7 @@
     <option name="ANNOTATION_PARAMETER_WRAP" value="1" />
     <option name="IMPORT_LAYOUT_TABLE">
       <value>
+        <package name="" withSubpackages="true" static="false" module="true" />
         <package name="android" withSubpackages="true" static="false" />
         <emptyLine />
         <package name="com" withSubpackages="true" static="false" />
@@ -65,15 +66,13 @@
         <package name="" alias="true" withSubpackages="true" />
       </value>
     </option>
-    <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-    <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+    <option name="LINE_BREAK_AFTER_MULTILINE_WHEN_ENTRY" value="false" />
     <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
   </JetCodeStyleSettings>
   <XML>
     <option name="XML_KEEP_LINE_BREAKS" value="true" />
     <option name="XML_KEEP_BLANK_LINES" value="1" />
     <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="false" />
-    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
   </XML>
   <codeStyleSettings language="Groovy">
     <indentOptions>


### PR DESCRIPTION
The important rule is `LINE_BREAK_AFTER_MULTILINE_WHEN_ENTRY`, which seems to be a new one and which we definitely want to be turned off (0 lines) 😄 the rest seems more like a cleanup from the IDE since I just re-exported the existing Infinum code style.